### PR TITLE
Fix two output glitches

### DIFF
--- a/lunatest.lua
+++ b/lunatest.lua
@@ -709,6 +709,11 @@ end
 function run(hooks, suite_filter)
    -- also check the namespace it's run in
    local opts = cmd_line_switches(lt_arg)
+
+   -- Make stdout line-buffered for better interactivity when the output is
+   -- not going to the terminal, e.g. is piped to another program.
+   io.stdout:setvbuf("line")
+
    if hooks == true or (hooks == nil and opts.verbose) then
       hooks = verbose_hooks
    else


### PR DESCRIPTION
These fix two minor output glitches. The second one being rather important for processing of lunatest output.

Without the second fix the lunatest output will arrive in chunks when piped to another command or redirected to file, thus making it hard to judge the testing progress.

Thank you :)
