### PR TITLE
fix test function discovery regexp

### DIFF
--- a/lunatest.lua
+++ b/lunatest.lua
@@ -562,10 +562,10 @@ local suites = {}
 local failed_suites = {}
 
 ---Check if a function name should be considered a test key.
--- Defaults to functions starting or ending with "test", with
--- leading underscores allowed.
+-- Defaults to functions starting with "test", with leading
+-- underscores allowed.
 function is_test_key(k)
-   return type(k) == "string" and k:match("_*test.*")
+   return type(k) == "string" and k:match("^_*test")
 end
 
 local function get_tests(mod)

--- a/test.lua
+++ b/test.lua
@@ -193,6 +193,26 @@ function test_assert_error()
                 end)
 end
 
+-- Test different test name conventions
+
+function __test_name()
+end
+
+function testCamelCase()
+end
+
+function some_test()
+    fail('wrong function name')
+end
+
+function this_test_should_not_run()
+    fail('wrong function name')
+end
+
+function thistestshouldnotrun()
+    fail('wrong function name')
+end
+
 -- This caused a crash when matching a string with invalid % escapes.
 -- Thanks to Diab Jerius for the bugfix.
 function test_failure_formatting()


### PR DESCRIPTION
Currently code looks for functions with the word "test" anywhere in its name.
This commit makes is_test_key accept functions starting with optional underscores and the word "test".

This code introduces backwards incompatibility, but I suppose uncommon formats are not (ab)used too much by anyone.
