### PR TITLE
Upgrade to Lua 5.2, but keep compatible with Lua 5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ It's largely upwardly compatible from [lunit][], with the following changes:
   not change any functions from the standard library.
 * If running tests in only one file, no module declaration is necessary.
 * For multiple suites, register them with lunatest.suite("file").
-  This uses require to load the suite, and uses the same methods to
-  match filenames with modules. (Note: should use module(...) in the file.)
+  This uses require the file suite to return a table containing the suite
+  related functions as well as the test functions. (Note: non local tests
+  functions found outside the returned table go to the main suite.)
 * It doesn't have any dependencies except Lua, though if present, it
   will use lhf's [lrandom][] module (for consistent pseudorandom numbers
   across operating systems) and [luasocket][]'s gettime() for timestamps).

--- a/lunatest-0.9.5-0.rockspec
+++ b/lunatest-0.9.5-0.rockspec
@@ -1,8 +1,8 @@
 package = "lunatest"
-version = "0.9.1-0"
+version = "0.9.5-0"
 source = {
    url = "git://github.com/silentbicycle/lunatest.git",
-   tag = "v0.9.1"
+   tag = "v0.9.5"
 }
 description = {
    summary = "xUnit-style + randomized unit testing framework",
@@ -25,5 +25,5 @@ build = {
    type = "builtin",
    modules = {
       lunatest = "lunatest.lua"
-   }           
+   }
 }

--- a/suite-hooks-fail.lua
+++ b/suite-hooks-fail.lua
@@ -1,13 +1,19 @@
-module(..., package.seeall)
+-- @module suite-hooks-fail
+local suite_hooks_fail = {}
+
+local lunatest = package.loaded.lunatest
+local assert_true = lunatest.assert_true
 
 -- Either returning false or erroring out in suite_setup()
 -- will prevent the suite from running.
-function suite_setup()
+function suite_hooks_fail.suite_setup()
    print "\n\n-- (about to fail and abort suite)"
    if true then return false end
    error("don't run this suite")
 end
 
-function test_never_run()
+function suite_hooks_fail.test_never_run()
    assert_true(false, "this suite should never be run")
 end
+
+return suite_hooks_fail

--- a/suite-hooks.lua
+++ b/suite-hooks.lua
@@ -1,13 +1,19 @@
-module(..., package.seeall)
+-- @module suite_hooks
+local suite_hooks = {}
 
-function suite_setup()
+local lunatest = package.loaded.lunatest
+local assert_true = lunatest.assert_true
+
+function suite_hooks.suite_setup()
    print "\n\n-- running suite setup hook"
 end
 
-function suite_teardown()
+function suite_hooks.suite_teardown()
    print "\n\n-- running suite teardown hook"
 end
 
-function test_ok()
+function suite_hooks.test_ok()
    assert_true(true)
 end
+
+return suite_hooks

--- a/suite-with-random-tests.lua
+++ b/suite-with-random-tests.lua
@@ -1,18 +1,27 @@
-module(..., package.seeall)
+-- @module suite_with_random_tests
+local suite_with_random_tests = {}
 
 -- Several random tests, with arguments specified both
 -- via functions and via consts.
 
 local seed = os.time()
+local lunatest = package.loaded.lunatest
 lunatest.set_seed(seed)
 print("Seed is ", seed)
 
-local random_bool, random_int = 
-   lunatest.random_bool, lunatest.random_int
-local random_float, random_string = 
-   lunatest.random_float, lunatest.random_string
+local random_bool= lunatest.random_bool
+local random_int = lunatest.random_int
+local random_float = lunatest.random_float
+local random_string = lunatest.random_string
+local assert_random = lunatest.assert_random
+local assert_len = lunatest.assert_len
+local assert_match = lunatest.assert_match
+local assert_boolean = lunatest.assert_boolean
+local assert_lt, assert_lte = lunatest.assert_lt, lunatest.assert_lte
+local assert_gt, assert_gte = lunatest.assert_gt, lunatest.assert_gte
+local assert_number= lunatest.assert_number
 
-function test_random_bool()
+function suite_with_random_tests.test_random_bool()
    assert_random("bool is t or f",
                  function (b)
                     return b == true or b == false
@@ -20,7 +29,7 @@ function test_random_bool()
 end
 
 
-function test_random_bool2()
+function suite_with_random_tests.test_random_bool2()
    assert_random("bool is t or f",
                  function ()
                     return random_bool()
@@ -28,7 +37,7 @@ function test_random_bool2()
 end
 
 
-function test_random_int()
+function suite_with_random_tests.test_random_int()
    assert_random({name="pos int", count=1000 },
                  function ()
                     local ri = random_int(1, 10) 
@@ -36,14 +45,14 @@ function test_random_int()
                  end)
 end
 
-function test_random_int2()
+function suite_with_random_tests.test_random_int2()
    assert_random({ name="pos int", count=1000 },
                  function (ri)
                     return ri >= 0 and ri <= 10
                  end, 10)
 end
 
-function test_neg_int()
+function suite_with_random_tests.test_neg_int()
    assert_random({ name="neg int", count=1000 },
                  function ()
                     local ni = random_int(-math.huge, 0)
@@ -51,7 +60,7 @@ function test_neg_int()
                  end)
 end
 
-function test_neg_or_pos_int()
+function suite_with_random_tests.test_neg_or_pos_int()
    assert_random({ name="neg int", count=1000 },
                  function (i)
                     assert_number(i)
@@ -61,7 +70,7 @@ function test_neg_or_pos_int()
 end
 
 
-function test_random_int_trio()
+function suite_with_random_tests.test_random_int_trio()
    assert_random({ name="three ints", count=1000 },
                  function ()
                     local ri = random_int
@@ -72,7 +81,7 @@ function test_random_int_trio()
                  end)
 end
 
-function test_random_float()
+function suite_with_random_tests.test_random_float()
    assert_random({ name="float", count=1000 },
                  function ()
                     local rf = random_float
@@ -80,7 +89,7 @@ function test_random_float()
                  end)
 end
 
-function test_random_float2()
+function suite_with_random_tests.test_random_float2()
    assert_random({ name="float", count=1000 },
                  function (x)
                     assert_gt(0, x)
@@ -88,7 +97,7 @@ function test_random_float2()
 end
 
 
-function test_random_string()
+function suite_with_random_tests.test_random_string()
    assert_random("vowels",
                  function (x)
                     local len = string.len(x)
@@ -97,7 +106,7 @@ function test_random_string()
                  end, "10 aeiou")
 end
 
-function test_random_string2()
+function suite_with_random_tests.test_random_string2()
    -- In the first argument, .always={...} is a list of seeds
    -- that will be run every trial.
    assert_random( { name="alpha",
@@ -110,7 +119,7 @@ function test_random_string2()
                  end, "10,30 %a")
 end
 
-function test_coinflip()
+function suite_with_random_tests.test_coinflip()
    local function rbool() return random_bool() end
    -- typically, this would go in a metatable...
    local coin = { __random = rbool }
@@ -121,7 +130,7 @@ function test_coinflip()
 end
 
 
-function test_random_int_bounds()
+function suite_with_random_tests.test_random_int_bounds()
    for run, pair in ipairs{ {1, 2}, {2, 10}, {-1, 1}, 
                             {-100, 100}, {-1, 0}, {0, 1} } do
       assert_random("int_bounds",
@@ -133,7 +142,7 @@ function test_random_int_bounds()
    end
 end
 
-function test_random_int_bounds()
+function suite_with_random_tests.test_random_int_bounds()
    for run, pair in ipairs{ {1, 2}, {2, 10}, {-1, 1}, 
                             {-100, 100}, {-1, 0}, {0, 1} } do
       assert_random("float_bounds",
@@ -146,7 +155,7 @@ function test_random_int_bounds()
 end
 
 
-function test_random_str_len()
+function suite_with_random_tests.test_random_str_len()
    local fmt = string.format
    for _,l in ipairs{ 1, 5, 10, 15, 30 } do
       assert_random("strlen",
@@ -160,7 +169,7 @@ function test_random_str_len()
 end
 
 
-function test_random_str_range()
+function suite_with_random_tests.test_random_str_range()
    local fmt = string.format
    assert_random("strlen2",
                  function()
@@ -170,3 +179,5 @@ function test_random_str_range()
                     assert_match("^%l+$", rs)
                  end)
 end
+
+return suite_with_random_tests

--- a/test-error_handler.lua
+++ b/test-error_handler.lua
@@ -1,4 +1,4 @@
-require "lunatest"
+local lunatest = require "lunatest"
 
 -- This should error out with a more meaningful error message
 -- than "./lunatest.lua:608: attempt to index local 'e' (a function value)".

--- a/test-teardown_fail.lua
+++ b/test-teardown_fail.lua
@@ -1,4 +1,4 @@
-require "lunatest"
+local lunatest = require "lunatest"
 
 function busywait(n)
    n = n or 10000

--- a/test.lua
+++ b/test.lua
@@ -1,5 +1,23 @@
 pcall(require, "luacov")    --measure code coverage, if luacov is present
-require "lunatest"
+local lunatest = require "lunatest"
+local assert_true, assert_false = lunatest.assert_true, lunatest.assert_false
+local assert_diffvars = lunatest.assert_diffvars
+local assert_boolean, assert_not_boolean = lunatest.assert_boolean, lunatest.assert_not_boolean
+local assert_len, assert_not_len = lunatest.assert_len, lunatest.assert_not_len
+local assert_match, assert_not_match = lunatest.assert_match, lunatest.assert_not_match
+local assert_error = lunatest.assert_error
+local assert_lt, assert_lte = lunatest.assert_lt, lunatest.assert_lte
+local assert_gt, assert_gte = lunatest.assert_gt, lunatest.assert_gte
+local assert_nil, assert_not_nil = lunatest.assert_nil, lunatest.assert_not_nil
+local assert_equal, assert_not_equal = lunatest.assert_equal, lunatest.assert_not_equal
+local assert_string, assert_not_string = lunatest.assert_string, lunatest.assert_not_string
+local assert_metatable, assert_not_metatable = lunatest.assert_metatable, lunatest.assert_not_metatable
+local assert_userdata, assert_not_userdata = lunatest.assert_userdata, lunatest.assert_not_userdata
+local assert_thread, assert_not_thread = lunatest.assert_thread, lunatest.assert_not_thread
+local assert_function, assert_not_function = lunatest.assert_function, lunatest.assert_not_function
+local assert_table, assert_not_table = lunatest.assert_table, lunatest.assert_not_table
+local assert_number, assert_not_number = lunatest.assert_number, lunatest.assert_not_number
+local skip, fail = lunatest.skip, lunatest.fail
 
 print '=============================='
 print('To test just the random suite, add "-s random" to the command line')


### PR DESCRIPTION
Done in this commit:
- upgrade module declaration and loading:
  - "module" idioms are replaced by returning the module table
  - declare a local variable for the loaded module
  - declare private function local and export module functions through
    the module table
- upgrade the getenv function by calling or emulating getfenv
- export the is_test_key function to enable customization
- suites are stored in an indexed table to run suite in the same order
  they are added. Tests are run in arbitrary order.
- update tests and test suites files
- bumps to version 0.9.5 and update the rockspec accordingly:
  No need to fix "lua >= 5.1" to "lua = 5.1" thanks to this upgrade.
- update README.md

Has been tested successfully with Lua 5.1, Lua 5.2 and luajit 2.0.3.
