### PR TITLE
getenv errors on lua 5.1.5 under Linux. Change to os.getenv

### DIFF
--- a/lunatest.lua
+++ b/lunatest.lua
@@ -740,7 +740,7 @@ function lunatest.run(hooks, opts)
    results.t_pre = now()
 
    -- If it's all in one test file, check its environment, too.
-   local env = getenv(3)
+   local env = os.getenv(3)
    if env then
       local main_suite = {name = "main", tests = get_tests(env)}
       table.insert(suites, main_suite)


### PR DESCRIPTION
getenv fails on Lua 5.1.5, Ubuntu version 14.04. Changed to os.getenv
