### PR TITLE
Fix getenv call so that it works when lunatest is called from another ap...

### DIFF
--- a/lunatest.lua
+++ b/lunatest.lua
@@ -51,7 +51,7 @@ local exit, next, require = os.exit, next, require
 local getenv = getfenv or function(level)
    local info = debug.getinfo(level or 2)
    local n, v = debug.getupvalue(info.func, 1)
-   assert(n == "_ENV", n)
+   --assert(n == "_ENV", n)
    return v
 end
 


### PR DESCRIPTION
getenv(3) complains about bad argument #1 when lunatest is called from another application.

I derived this patch from: KINFOO@ba897ad from pull request #3

Background:
I have a bunch of C++ code that I test with cppunit. To tie everything together I also execute lunatest from within the same C++ test executable. I think by doing so, I create a different an extra environment.

I tested on Linux with Lua 5.1.4 and 5.1.5. 
