### PR TITLE
Allow assert_error to accept additional arguments

### DIFF
--- a/lunatest.lua
+++ b/lunatest.lua
@@ -441,8 +441,8 @@ function lunatest.assert_not_metatable(exp, val, msg)
 end
 
 ---Test that the function raises an error when called.
-function lunatest.assert_error(f, msg)
-   local ok, err = pcall(f)
+function lunatest.assert_error(f, msg, ...)
+   local ok, err = pcall(f, ...)
    local got = ok or err
    wraptest(not ok, msg,
             { exp="an error", got=got,

--- a/test.lua
+++ b/test.lua
@@ -211,6 +211,16 @@ function test_assert_error()
                 end)
 end
 
+function test_assert_error_with_args()
+   assert_error(function (a)
+                   if a ~= nil then
+                      error("*crash!*")
+                   end
+                end,
+                "function should crash when argument 1 is set",
+                "arg1")
+end
+
 -- This caused a crash when matching a string with invalid % escapes.
 -- Thanks to Diab Jerius for the bugfix.
 function test_failure_formatting()


### PR DESCRIPTION
This is the simplest way to fix #23, but not necessarily the most correct. Usually `msg` is the last argument to an `assert_*` function. Is there a way to do that here? I can't think of a way at the moment.