### PR TITLE
Fix default_hooks and verbose_hooks to not be global

### DIFF
--- a/lunatest.lua
+++ b/lunatest.lua
@@ -486,7 +486,7 @@ end
 
 
 ---Default behavior.
-default_hooks = {
+local default_hooks = {
    begin = false,
    begin_suite = function(s_env, tests)
                     iow(fmt("\n-- Starting suite %q, %d test(s)\n  ",
@@ -509,8 +509,8 @@ default_hooks = {
 
 
 ---Default verbose behavior.
-verbose_hooks = {
-   begin = function(res, suites)
+local verbose_hooks = {
+   begin = function(_, suites)
               local s_ct = count(suites)
               if s_ct > 0 then
                  printf("Starting tests, %d suite(s)", s_ct)


### PR DESCRIPTION
I think this likely got overlooked when the library got moved away from the old `module`-keyword-style to a "modern" module using locals.

Relatedly I noticed there are a few minor style issues pointed out by `luacheck`:

```
$ luacheck lunatest.lua 
Checking lunatest.lua                             33 warnings

    lunatest.lua:16:3: line contains trailing whitespace
    lunatest.lua:46:29: variable setmetatable was previously defined on line 42
    lunatest.lua:48:7: unused variable exit
    lunatest.lua:48:13: unused variable next
    lunatest.lua:64:7: variable debug was previously defined on line 38
    lunatest.lua:117:37: line contains trailing whitespace
    lunatest.lua:127:15: unused argument self
    lunatest.lua:129:15: unused argument self
    lunatest.lua:139:15: unused argument self
    lunatest.lua:141:15: unused argument self
    lunatest.lua:154:15: unused argument self
    lunatest.lua:156:15: unused argument self
    lunatest.lua:165:16: unused argument self
    lunatest.lua:167:16: unused argument self
    lunatest.lua:497:25: unused argument name
    lunatest.lua:579:65: line contains trailing whitespace
    lunatest.lua:583:21: unused variable r_err
    lunatest.lua:656:10: variable arg was previously defined as an argument on line 655
    lunatest.lua:673:8: unused loop variable k
    lunatest.lua:673:10: unused loop variable f
    lunatest.lua:676:8: unused loop variable k
    lunatest.lua:687:13: shadowing upvalue run_suite on line 682
    lunatest.lua:725:10: variable opts was previously defined as an argument on line 723
    lunatest.lua:864:10: variable len was previously defined on line 830
    lunatest.lua:868:20: shadowing upvalue idx on line 829
    lunatest.lua:898:1: line contains only whitespace
    lunatest.lua:901:25: accessing undefined variable self
    lunatest.lua:988:14: unused loop variable i
    lunatest.lua:1030:1: line contains only whitespace
    lunatest.lua:1112:1: line contains only whitespace
    lunatest.lua:1136:10: unused variable overall_status
    lunatest.lua:1136:28: accessing undefined variable passed
    lunatest.lua:1137:1: line contains only whitespace

Total: 33 warnings / 0 errors in 1 file
```

If you're interested I can see about cleaning those up as well, or a subset of them that you consider worth addressing. I've found `luacheck` to be indispensible for spotting bugs like this accidental global every time I write any Lua code.