### PR TITLE
Don't assume debug.getupvalue will give _ENV.

### DIFF
--- a/lunatest.lua
+++ b/lunatest.lua
@@ -51,8 +51,9 @@ local exit, next, require = os.exit, next, require
 local getenv = getfenv or function(level)
    local info = debug.getinfo(level or 2)
    local n, v = debug.getupvalue(info.func, 1)
-   assert(n == "_ENV", n)
-   return v
+   if(n == "_ENV") then
+     return v
+   end
 end
 
 ---Use lhf's random, if available. It provides an RNG with better


### PR DESCRIPTION
Right now the code asserts that that getupvalue will always return
_ENV, but in the example below that never happens. It appears this
function is only ever called in the situation where tests are defined
globally instead of being pulled from modules, so if we can't actually
get _ENV we should just assume that we'll be given the tests in
modules rather than looking for globals.

The current implementation fails with the following code on all but
PUC 5.1. For a file getenv.lua:

    local t = require("lunatest")
    t.suite("mysuite") -- mysuite.lua contains just: return {}
    return t.run()

We get these results:

```
~/src/lunatest $ lua5.4 getenv.lua
/home/phil/bin/lua5.4: (error object is a nil value)
stack traceback:
 [C]: in function 'assert'
 ./lunatest.lua:54: in upvalue 'getenv'
 ./lunatest.lua:743: in function 'lunatest.run'
 (...tail calls...)
 [C]: in ?
~/src/lunatest $ lua5.3 getenv.lua
/usr/bin/lua5.3: (error object is a nil value)
stack traceback:
 [C]: in function 'assert'
 ./lunatest.lua:54: in upvalue 'getenv'
 ./lunatest.lua:743: in function 'lunatest.run'
 (...tail calls...)
 [C]: in ?
~/src/lunatest $ lua5.2 getenv.lua
/usr/bin/lua5.2: ./lunatest.lua:54: assertion failed!
stack traceback:
 [C]: in function 'assert'
 ./lunatest.lua:54: in function 'getenv'
 ./lunatest.lua:743: in function <./lunatest.lua:723>
 (...tail calls...)
 [C]: in ?
~/src/lunatest $ lua5.1 getenv.lua # exits successfully
```

On the other hand, this will not fix it for LuaJIT, which already has
getfenv and thus never even attempts to run our replacement getenv
function:

```
~/src/lunatest $ luajit getenv.lua
luajit: ./lunatest.lua:743: bad argument #1 to 'getenv' (invalid level)
stack traceback:
 [C]: in function 'getenv'
 ./lunatest.lua:743: in function <./lunatest.lua:723>
 [C]: at 0x5643252031d0
```

So perhaps it would be better to keep the function as-is and move it
to a pcall instead? I can submit a patch for this instead if you prefer.